### PR TITLE
refactor/docs: centralize stow logic, update configs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # My config files
 
-
 My dot config files for my Linux/Mac systems.
 
 They are managed by [GNU-stow](https://www.gnu.org/software/stow/).
-
 
 ## Setup
 
@@ -16,16 +14,16 @@ $ git clone https://github.com/ZuoAnZoom/.myconfig.git $HOME/.myconfig
 
 2. Setup.
 
-Using `config.sh` to set up. Including both apps and configs.
+Using `config.sh` to set up both apps and configs.
 
 ```shell
-$ bash -c '$HOME/.myconfig/config.sh'  # it will setup stow, wget, git, zsh, tmux, fzf by default.
+$ bash -c '$HOME/.myconfig/config.sh'  # setup stow, wget, git, zsh, tmux, fzf by default.
 $ bash -c '$HOME/.myconfig/config.sh nvim <other-app> ...'  # add other apps
 ```
 
 FYI:
 
-- If you only need the dot files, install stow first, then using stow to set up the dot files.
+- If you only need the dot files, install stow first, then use stow to set up the dot files.
 
 ```shell
 $ sudo apt install stow
@@ -42,19 +40,44 @@ $ stow ...
 $ cd $HOME && git clone https://github.com/ZuoAnZoom/.myconfig.git && cd .myconfig && bash -c './ln.sh'
 ```
 
+## Script structure
+
+- `config.sh`: unified entrypoint for package installation and dotfile setup.
+- `scripts/config-*.sh`: per-app install/config script.
+- `scripts/utils.sh`: shared helpers (logging, install checks, and `stow_package` for reusable dotfile stow flow).
+
+### Dotfile stow flow (refactored)
+
+The stow steps for `zsh` / `tmux` / `nvim` / `git` are centralized into `stow_package`:
+
+1. remove existing target file/symlink if it exists;
+2. run `stow` from repo root;
+3. print unified success/failure logs.
+
+This reduces duplicated shell logic and keeps behavior consistent across app config scripts.
+
+## Development
+
+### Push current branch to remote
+
+```shell
+$ git push -u origin <branch-name>
+```
 
 ## Reference
 
 ### Tmux
+
 Use [oh my tmux](https://github.com/gpakosz/.tmux) with some customize options.
 
-
 ### zsh
+
 Use [oh my zsh](https://ohmyz.sh).
 
 FYI: Include fzf, nvim setups.
 
 ### Git
+
 Use [git-delta](https://github.com/dandavison/delta) with some customize options.
 
 FYI: [git-lfs](https://git-lfs.com/) required.

--- a/scripts/config-git.sh
+++ b/scripts/config-git.sh
@@ -33,13 +33,7 @@ function install_git_delta() {
 }
 
 function set_config() {
-    if [ -f "$HOME/.gitconfig" ]; then
-        echo_warn "remove existing $HOME/.gitconfig"
-        rm -rf $HOME/.gitconfig
-    fi
-
-    cd "$(dirname "$0")/../" && stow $STOW_OPTIONS git 
-    echo_info "stow git config successfully."
+    stow_package "git" "$HOME/.gitconfig"
 }
 
 

--- a/scripts/config-nvim.sh
+++ b/scripts/config-nvim.sh
@@ -10,13 +10,7 @@ elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
 fi
 
 function set_config() {
-    if [ -d "$HOME/.config/nvim" ]; then
-        echo_warn "remove existing $HOME/.config/nvim"
-        rm -rf $HOME/.config/nvim
-    fi
-
-    cd "$(dirname "$0")/../" && stow $STOW_OPTIONS nvim
-    echo_info "stow nvim config successfully."
+    stow_package "nvim" "$HOME/.config/nvim"
 }
 
 # check installed
@@ -29,7 +23,7 @@ fi
 
 function install_nvim() {
     trap 'return 1' ERR
-    
+
     echo_info "Downloading $APP_NAME..."
     wget https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
 

--- a/scripts/config-tmux.sh
+++ b/scripts/config-tmux.sh
@@ -6,18 +6,7 @@ PACKAGE_MANAGER=$1
 APP_NAME="tmux"
 
 function set_config() {
-    # set config
-    if [ -f "$HOME/.tmux.conf" ]; then
-        echo_warn "remove existing $HOME/.tmux.conf"
-        rm -rf $HOME/.tmux.conf
-    fi
-    if [ -f "$HOME/.tmux.conf.local" ]; then
-        echo_warn "remove existing $HOME/.tmux.conf.local"
-        rm -rf $HOME/.tmux.conf.local
-    fi
-
-    cd "$(dirname "$0")/../" && stow $STOW_OPTIONS tmux
-    echo_info "stow tmux config successfully."
+    stow_package "tmux" "$HOME/.tmux.conf" "$HOME/.tmux.conf.local"
 }
 
 # check installed

--- a/scripts/config-zsh.sh
+++ b/scripts/config-zsh.sh
@@ -6,13 +6,7 @@ PACKAGE_MANAGER=$1
 APP_NAME="zsh"
 
 function set_config() {
-    if [ -f "$HOME/.zshrc" ]; then
-        echo_warn "remove existing $HOME/.zshrc"
-        rm -rf $HOME/.zshrc
-    fi
-    
-    cd "$(dirname "$0")/../" && stow $STOW_OPTIONS zsh
-    echo_info "stow zsh config successfully."
+    stow_package "zsh" "$HOME/.zshrc"
 }
 
 function install_oh_my_zsh() {
@@ -34,7 +28,7 @@ function install_zsh_autosuggestions() {
         echo_info "zsh-autosuggestions already installed."
         return 0
     fi
-    
+
     echo_info "Installing zsh-autosuggestions..."
     git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -27,3 +27,29 @@ function check_app_installed() {
         return 0
     fi
 }
+
+function stow_package() {
+    local package_name="$1"
+    shift
+    local target_paths=("$@")
+
+    for path in "${target_paths[@]}"; do
+        if [ -e "$path" ] || [ -L "$path" ]; then
+            echo_warn "remove existing $path"
+            rm -rf "$path"
+        fi
+    done
+
+    (
+        cd "$(dirname "$0")/../" || return 1
+        stow $STOW_OPTIONS "$package_name"
+    )
+
+    if [ $? -ne 0 ]; then
+        echo_error "stow $package_name config failed."
+        return 1
+    fi
+
+    echo_info "stow $package_name config successfully."
+    return 0
+}


### PR DESCRIPTION
### Motivation
- Centralize repeated `rm + stow + log` logic into a single helper to make dotfile installation consistent and reduce duplication. 
- Update per-app setup scripts to use the shared helper so behavior is uniform across `zsh`, `tmux`, `nvim`, and `git`.
- Clarify README setup instructions and document the refactored stow flow and development push steps.

### Description
- Added `stow_package()` helper to `scripts/utils.sh` which removes existing targets, runs `stow` from the repo root, and prints unified success/failure logs. 
- Refactored `scripts/config-zsh.sh`, `scripts/config-tmux.sh`, `scripts/config-nvim.sh`, and `scripts/config-git.sh` to call `stow_package` with appropriate package name and target path(s) instead of duplicating removal + stow logic. 
- Improved `README.md` wording in the Setup section, added a `Script structure` section describing `config.sh`, `scripts/config-*.sh`, and `scripts/utils.sh`, and documented the `Dotfile stow flow (refactored)` and a `Development` snippet for pushing branches. 
- Minor whitespace/newline cleanups in scripts to keep formatting consistent.

### Testing
- Ran repository verification and metadata commands: `git status --short --branch`, `git branch --show-current`, and `git remote -v` which succeeded. 
- Inspected and edited README using `sed`/here-doc and verified changes with `git diff -- README.md` and `nl -ba README.md`, and these checks succeeded. 
- Committed the README update with `git add README.md && git commit -m "docs: improve README for refactored dotfile flow"` which created commit `9213239` successfully. 
- Attempted to push the branch with `git push -u origin refactor/dotfile-install` but the push failed due to network/tunnel restrictions: `CONNECT tunnel failed, response 403`. 
- Created PR metadata indicating branch, commit, and push status (local branch ready; remote push blocked by environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b58fc56c8324b4de84e9ba9a9284)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly refactors duplicated shell logic into a shared helper and updates documentation; behavior changes are limited to how existing dotfiles are removed/stowed and how failures are logged/returned.
> 
> **Overview**
> Centralizes dotfile stow setup into a new `stow_package` helper in `scripts/utils.sh`, which removes existing target paths, runs `stow` from repo root, and standardizes success/failure logging.
> 
> Refactors per-app config scripts (`config-zsh.sh`, `config-tmux.sh`, `config-nvim.sh`, `config-git.sh`) to use `stow_package` instead of duplicating `rm + stow` logic, and cleans up minor newline/formatting issues.
> 
> Updates `README.md` to clarify setup wording and document script structure, the refactored stow flow, and a brief development snippet for pushing branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31ab2d6f0d9d9798ce1c026c4144db74bfd3a17c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->