### PR TITLE
feat: add zoxide installer and include in default setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ git clone https://github.com/ZuoAnZoom/.myconfig.git $HOME/.myconfig
 Using `config.sh` to set up both apps and configs.
 
 ```shell
-$ bash -c '$HOME/.myconfig/config.sh'  # setup stow, wget, git, zsh, tmux, fzf by default.
+$ bash -c '$HOME/.myconfig/config.sh'  # setup stow, wget, git, zsh, tmux, fzf, zoxide by default.
 $ bash -c '$HOME/.myconfig/config.sh nvim <other-app> ...'  # add other apps
 ```
 

--- a/config.sh
+++ b/config.sh
@@ -54,7 +54,7 @@ fi
 
 
 user_apps=("$@")
-required_apps=("stow" "wget" "git" "zsh" "tmux" "fzf")
+required_apps=("stow" "wget" "git" "zsh" "tmux" "fzf" "zoxide")
 all_apps=("${required_apps[@]}" "${user_apps[@]}")
 failed_apps=()
 

--- a/scripts/config-zoxide.sh
+++ b/scripts/config-zoxide.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source "$(dirname "$0")/utils.sh"
+
+PACKAGE_MANAGER=$1
+APP_NAME="zoxide"
+
+# check installed
+check_app_installed "$APP_NAME"
+if [ $? -eq 0 ]; then
+    echo_info "Skipping installation steps for $APP_NAME."
+    exit 0
+fi
+
+# install
+if [[ "$PACKAGE_MANAGER" == "apt" ]]; then
+    sudo apt install -y $APP_NAME
+    if [ $? -ne 0 ]; then
+        echo_error "$APP_NAME installation failed."
+        exit 1
+    fi
+elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
+    brew install $APP_NAME
+    if [ $? -ne 0 ]; then
+        echo_error "$APP_NAME installation failed."
+        exit 1
+    fi
+fi
+
+# check install
+check_app_installed "$APP_NAME"
+if [ $? -ne 0 ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
### Motivation
- Provide automated installation and configuration for `zoxide` as part of the unified setup flow to make the environment jump utility available by default.
- Ensure `config.sh` can include `zoxide` in its standard set of apps so users running the primary setup get `zoxide` without extra steps.

### Description
- Add new installer script `scripts/config-zoxide.sh` which checks for an existing `zoxide` installation, installs via `apt` or `brew`, and verifies the installation exit status.
- Update `config.sh` to include `zoxide` in the `required_apps` array so it is installed as part of the default setup.
- Update `README.md` to mention that `zoxide` is included in the default install list.
- Make the new script executable and keep the same logging/check patterns used by other `scripts/config-*.sh` helpers.

### Testing
- Performed a shell syntax check with `bash -n config.sh scripts/config-zoxide.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1831158680832486228f8b895dfbd3)