### PR TITLE
Use upstream zoxide install script with apt/brew fallback

### DIFF
--- a/scripts/config-zoxide.sh
+++ b/scripts/config-zoxide.sh
@@ -6,6 +6,7 @@ source "$(dirname "$0")/utils.sh"
 
 PACKAGE_MANAGER=$1
 APP_NAME="zoxide"
+export PATH="$HOME/.local/bin:$PATH"
 INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh"
 
 # check installed

--- a/scripts/config-zoxide.sh
+++ b/scripts/config-zoxide.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+set -o pipefail
+
 source "$(dirname "$0")/utils.sh"
 
 PACKAGE_MANAGER=$1
 APP_NAME="zoxide"
+INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh"
 
 # check installed
 check_app_installed "$APP_NAME"
@@ -12,17 +15,25 @@ if [ $? -eq 0 ]; then
     exit 0
 fi
 
-# install
-if [[ "$PACKAGE_MANAGER" == "apt" ]]; then
-    sudo apt install -y $APP_NAME
-    if [ $? -ne 0 ]; then
-        echo_error "$APP_NAME installation failed."
-        exit 1
-    fi
-elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
-    brew install $APP_NAME
-    if [ $? -ne 0 ]; then
-        echo_error "$APP_NAME installation failed."
+# install with official install script first, then fall back to package manager
+curl -sSfL "$INSTALL_SCRIPT_URL" | sh
+if [ $? -ne 0 ]; then
+    echo_error "$APP_NAME install script failed. Falling back to $PACKAGE_MANAGER."
+
+    if [[ "$PACKAGE_MANAGER" == "apt" ]]; then
+        sudo apt install -y "$APP_NAME"
+        if [ $? -ne 0 ]; then
+            echo_error "$APP_NAME installation failed."
+            exit 1
+        fi
+    elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
+        brew install "$APP_NAME"
+        if [ $? -ne 0 ]; then
+            echo_error "$APP_NAME installation failed."
+            exit 1
+        fi
+    else
+        echo_error "unsupported package manager: $PACKAGE_MANAGER"
         exit 1
     fi
 fi

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -209,6 +209,11 @@ export PATH="$PATH:/opt/nvim-linux64/bin"
 # fzf install by git
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
+# zoxide
+if command -v zoxide &> /dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
 fi
 
 # >>> conda initialize >>>


### PR DESCRIPTION
### Motivation
- Ensure `zoxide` is installed using the official upstream installer by default to match recommended installation and improve reliability.
- Detect failures in the install pipeline so the script can gracefully fall back to package managers when the upstream installer fails.

### Description
- Updated `scripts/config-zoxide.sh` to run the upstream installer via `curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh` and added `INSTALL_SCRIPT_URL` to centralize the URL.
- Added `set -o pipefail` at the top of `scripts/config-zoxide.sh` so pipeline failures from `curl` or the installer are detected.
- Implemented fallback logic to install with `apt` (`sudo apt install -y "zoxide"`) or `brew` (`brew install "zoxide"`) if the upstream install script exits with a non-zero status.

### Testing
- Ran `bash -n scripts/config-zoxide.sh` and the syntax check completed successfully.
- Attempted `shellcheck scripts/config-zoxide.sh` but `shellcheck` is not available in the environment, so static linting was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46287cc4908324baa984a8d7739009)